### PR TITLE
Declare required packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "scripts": {
     "test": "apm test"
   },
+  "package-deps": [
+    "refactor"
+  ],
   "dependencies": {
     "babel-traverse": "^6.10.4",
     "babylon": "^6.8.1",


### PR DESCRIPTION
If one Atom package requires another to be installed, you can list the dependencies in `package.json` using the `package-deps` array:

``` json
"package-deps": [
    "refactor"
]
```

Like NPM modules required with `dependencies`, these are automatically installed... so there's no need for users to manually install one package before installing another.
